### PR TITLE
Lttng tweak tracepoints

### DIFF
--- a/sched_rt_tp.h
+++ b/sched_rt_tp.h
@@ -26,45 +26,40 @@ TRACEPOINT_EVENT(
 TRACEPOINT_EVENT(
     sched_rt,
     job_release_recv,
-    TP_ARGS(unsigned int, vtid),
+    TP_ARGS(pid_t, vpid, pthread_t, vtid),
     TP_FIELDS(
-        ctf_integer(unsigned int, vtid, vtid)
+        ctf_integer(pid_t, vpid, vpid)
+        ctf_integer(pthread_t, vtid, vtid)
     )
 )
 
 TRACEPOINT_EVENT(
     sched_rt,
     thread_preempt,
-    TP_ARGS(unsigned int, vtid),
+    TP_ARGS(pid_t, vpid, pthread_t, vtid),
     TP_FIELDS(
-        ctf_integer(unsigned int, vtid, vtid)
+        ctf_integer(pid_t, vpid, vpid)
+        ctf_integer(pthread_t, vtid, vtid)
     )
 )
 
 TRACEPOINT_EVENT(
     sched_rt,
     thread_suspend,
-    TP_ARGS(unsigned int, vtid),
+    TP_ARGS(pid_t, vpid, pthread_t, vtid),
     TP_FIELDS(
-        ctf_integer(unsigned int, vtid, vtid)
+        ctf_integer(pid_t, vpid, vpid)
+        ctf_integer(pthread_t, vtid, vtid)
     )
 )
 
 TRACEPOINT_EVENT(
     sched_rt,
     thread_run,
-    TP_ARGS(unsigned int, vtid),
+    TP_ARGS(pid_t, vpid, pthread_t, vtid),
     TP_FIELDS(
-        ctf_integer(unsigned int, vtid, vtid)
-    )
-)
-
-TRACEPOINT_EVENT(
-    sched_rt,
-    deadline_overrun,
-    TP_ARGS(unsigned int, vtid),
-    TP_FIELDS(
-        ctf_integer(unsigned int, vtid, vtid)
+        ctf_integer(pid_t, vpid, vpid)
+        ctf_integer(pthread_t, vtid, vtid)
     )
 )
 

--- a/task_proc_tp.h
+++ b/task_proc_tp.h
@@ -19,8 +19,10 @@ TRACEPOINT_EVENT(
 TRACEPOINT_EVENT(
     task_proc,
     task_init,
-    TP_ARGS(float, period, float, deadline, float, wcet),
+    TP_ARGS(pid_t, vpid, pthread_t, vtid, float, period, float, deadline, float, wcet),
     TP_FIELDS(
+        ctf_integer(pid_t, vpid, vpid)
+        ctf_integer(pthread_t, vtid, vtid)
         ctf_float(float, period, period)
         ctf_float(float, deadline, deadline)
         ctf_float(float, wcet, wcet)
@@ -30,10 +32,8 @@ TRACEPOINT_EVENT(
 TRACEPOINT_EVENT(
     task_proc,
     job_release,
-    TP_ARGS(unsigned int, vtid),
-    TP_FIELDS(
-        ctf_integer(unsigned int, vtid, vtid)
-    )
+    TP_ARGS(),
+    TP_FIELDS()
 )
 
 TRACEPOINT_EVENT(
@@ -46,6 +46,13 @@ TRACEPOINT_EVENT(
 TRACEPOINT_EVENT(
     task_proc,
     kill_threads,
+    TP_ARGS(),
+    TP_FIELDS()
+)
+
+TRACEPOINT_EVENT(
+    task_proc,
+    deadline_overrun,
     TP_ARGS(),
     TP_FIELDS()
 )


### PR DESCRIPTION
removed scheduler tracepoints from userspace process (still kept definitions in sched_rt_tp.h)
added namespace tp in simulate_tasks.cpp in order to differentiate tracepoints from other stuff
replaced unsigned ints with pid_t and pthread_t to fix typing
did other formatting fixes