### PR TITLE
Modify lttng tracepoints, add helper scripts, and swap to spin-based work

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ taskset_short.txt
 temp
 simulate_tasks
 tracepoint_provider.o
+lttng_trace

--- a/README.md
+++ b/README.md
@@ -41,7 +41,8 @@ usage: sudo ./simulate_tasks <taskset_file> <runtime_seconds> [emit logs] [num_c
 ```
 sudo lttng create my_session
 sudo lttng enable-event -u 'task_proc:*'
-sudo lttng enable-event -u 'sched_rt:*'
+sudo lttng enable-event -k 'sched*'
+sudo lttng enable-event -k 'x86_irq_vectors_reschedule*'
 sudo lttng start
 sudo ./simulate_tasks taskset.txt 5 > temp
 sudo lttng stop

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,5 @@
+[ -f tracepoint_provider.o ] && rm tracepoint_provider.o
+[ -f simulate_tasks ] && rm simulate_tasks
+
+gcc  -c -I. tracepoint_provider.c -o tracepoint_provider.o -lttng-ust
+g++ -o simulate_tasks simulate_tasks.cpp tracepoint_provider.o -llttng-ust -ldl -lpthread

--- a/lttng_trace.sh
+++ b/lttng_trace.sh
@@ -1,0 +1,11 @@
+[ -d trace ] && sudo rm -rf lttng_trace
+sudo lttng destroy sched_trace
+sudo lttng create sched_trace --output lttng_trace
+sudo lttng enable-event -u 'task_proc:*'
+sudo lttng enable-event -k 'sched*'
+sudo lttng start
+sudo ./simulate_tasks taskset.txt 5 > temp
+sudo lttng stop
+# sudo lttng view
+sudo lttng destroy sched_trace
+sudo babeltrace2 lttng_trace > lttng_trace/bt2.txt

--- a/lttng_trace.sh
+++ b/lttng_trace.sh
@@ -1,4 +1,4 @@
-[ -d trace ] && sudo rm -rf lttng_trace
+[ -d lttng_trace ] && sudo rm -rf lttng_trace
 sudo lttng destroy sched_trace
 sudo lttng create sched_trace --output lttng_trace
 sudo lttng enable-event -u 'task_proc:*'

--- a/lttng_trace.sh
+++ b/lttng_trace.sh
@@ -3,6 +3,7 @@ sudo lttng destroy sched_trace
 sudo lttng create sched_trace --output lttng_trace
 sudo lttng enable-event -u 'task_proc:*'
 sudo lttng enable-event -k 'sched*'
+sudo lttng enable-event -k 'x86_irq_vectors_reschedule*'
 sudo lttng start
 sudo ./simulate_tasks taskset.txt 5 > temp
 sudo lttng stop

--- a/simulate_tasks.cpp
+++ b/simulate_tasks.cpp
@@ -94,7 +94,7 @@ static int sched_setattr(pid_t pid, struct sched_attr *attr, unsigned int flags)
 
 void sigxcpu_handler(int signum) {
     tp::deadline_overrun();
-    std::cout << "Thread " << pthread_self() << " exceeded its runtime" << std::endl;
+    std::cout << "Thread " << gettid() << " exceeded its runtime" << std::endl;
 }
 
 struct ThreadArg {
@@ -110,7 +110,7 @@ void set_cpu_affinity(int cpu_id) {
     cpu_set_t cpuset;
     CPU_ZERO(&cpuset);
     CPU_SET(cpu_id, &cpuset);
-    pthread_setaffinity_np(pthread_self(), sizeof(cpu_set_t), &cpuset);
+    pthread_setaffinity_np(gettid(), sizeof(cpu_set_t), &cpuset);
 }
 
 void* task_function(void* arg) {
@@ -121,7 +121,7 @@ void* task_function(void* arg) {
     //auto now = std::chrono::high_resolution_clock::now();
     //auto elapsed = std::chrono::duration_cast<std::chrono::microseconds>(now - global_start_time);
     //log_message << "task " << task.task_set << " arrived at " << elapsed.count() << " us" << std::endl;
-    tp::init_task(getpid(), pthread_self(), task.period, task.deadline, task.wcet);
+    tp::init_task(getpid(), gettid(), task.period, task.deadline, task.wcet);
 
     int cpu_id = threadArg->cpu_id;
 
@@ -163,7 +163,7 @@ void* task_function(void* arg) {
 	auto execution_end = std::chrono::high_resolution_clock::now();
     /*
 	if (execution_end - execution_start > std::chrono::microseconds(static_cast<int>(task.wcet * 1000))) {
-        preempt_thread(pthread_self());
+        preempt_thread(gettid());
     }
     */
 	tp::complete_job();

--- a/simulate_tasks.cpp
+++ b/simulate_tasks.cpp
@@ -149,7 +149,6 @@ void* task_function(void* arg) {
     while (should_continue.load()) {
         auto job_start = std::chrono::high_resolution_clock::now();
         long long current_job_id = ++threadArg->job_id;
-        tp::release_job(getpid(), gettid());
         auto elapsed = std::chrono::duration_cast<std::chrono::microseconds>(job_start - global_start_time);
         if (verbose){
         	// log job start
@@ -159,7 +158,8 @@ void* task_function(void* arg) {
             log_message(ss.str());
 	    }
 
-        uint64_t cap = (uint64_t)(5759000.f * 0.36764705882 * task.wcet);
+        uint64_t cap = (uint64_t)(2705000.f * task.wcet);
+        tp::release_job(getpid(), gettid());
         for (volatile uint64_t i = 0; i < cap; ++i);
         tp::complete_job(getpid(), gettid());
 
@@ -245,8 +245,8 @@ int main(int argc, char* argv[]) {
         threadargs[i].cpu_id = (num_cores > 1) ? (i % num_cores) : -1;
         pthread_create(&threads[i], NULL, task_function, &threadargs[i]);
     }
+    std::this_thread::sleep_for(std::chrono::milliseconds(500));
 
-    sleep(2);
     global_start_time = std::chrono::high_resolution_clock::now(); // Set global start time
     if (verbose) {
     	log_message("All tasks are released at 0 us\n");

--- a/task_proc_tp.h
+++ b/task_proc_tp.h
@@ -19,10 +19,10 @@ TRACEPOINT_EVENT(
 TRACEPOINT_EVENT(
     task_proc,
     task_init,
-    TP_ARGS(pid_t, vpid, pthread_t, vtid, float, period, float, deadline, float, wcet),
+    TP_ARGS(__pid_t, vpid, __pid_t, vtid, float, period, float, deadline, float, wcet),
     TP_FIELDS(
-        ctf_integer(pid_t, vpid, vpid)
-        ctf_integer(pthread_t, vtid, vtid)
+        ctf_integer(__pid_t, vpid, vpid)
+        ctf_integer(__pid_t, vtid, vtid)
         ctf_float(float, period, period)
         ctf_float(float, deadline, deadline)
         ctf_float(float, wcet, wcet)
@@ -32,15 +32,21 @@ TRACEPOINT_EVENT(
 TRACEPOINT_EVENT(
     task_proc,
     job_release,
-    TP_ARGS(),
-    TP_FIELDS()
+    TP_ARGS(__pid_t, vpid, __pid_t, vtid),
+    TP_FIELDS(
+        ctf_integer(__pid_t, vpid, vpid)
+        ctf_integer(__pid_t, vtid, vtid)
+    )
 )
 
 TRACEPOINT_EVENT(
     task_proc,
     job_completion,
-    TP_ARGS(),
-    TP_FIELDS()
+    TP_ARGS(__pid_t, vpid, __pid_t, vtid),
+    TP_FIELDS(
+        ctf_integer(__pid_t, vpid, vpid)
+        ctf_integer(__pid_t, vtid, vtid)
+    )
 )
 
 TRACEPOINT_EVENT(
@@ -53,8 +59,11 @@ TRACEPOINT_EVENT(
 TRACEPOINT_EVENT(
     task_proc,
     deadline_overrun,
-    TP_ARGS(),
-    TP_FIELDS()
+    TP_ARGS(__pid_t, vpid, __pid_t, vtid),
+    TP_FIELDS(
+        ctf_integer(__pid_t, vpid, vpid)
+        ctf_integer(__pid_t, vtid, vtid)
+    )
 )
 
 #endif


### PR DESCRIPTION
modifies tracepoints (swap from pid, tid to tid since sched_switch only operates on tid)
adds bash scripts to make building and tracing faster
replaces sleep with spin work that is near the wcet
